### PR TITLE
moved proptypes to its own import from react-native to 'prop-types'

### DIFF
--- a/Login/Forms/BaseForm/BaseForm.js
+++ b/Login/Forms/BaseForm/BaseForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import { Logo } from '../../Structure'
 
@@ -25,9 +26,9 @@ class BaseForm extends Component {
 }
 
 BaseForm.propTypes = {
-  logoStyle: React.PropTypes.any,
-  logoImage: React.PropTypes.any,
-  showLogo: React.PropTypes.bool
+  logoStyle: PropTypes.any,
+  logoImage: PropTypes.any,
+  showLogo: PropTypes.bool
 }
 
 export default BaseForm

--- a/Login/Structure/Button/Button.js
+++ b/Login/Structure/Button/Button.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Text, TouchableOpacity } from 'react-native'
 
 const Button = (props) => {
@@ -12,10 +13,10 @@ const Button = (props) => {
 }
 
 Button.propTypes = {
-  onPress: React.PropTypes.func,
-  style: React.PropTypes.any,
-  text: React.PropTypes.string,
-  textStyle: React.PropTypes.any
+  onPress: PropTypes.func,
+  style: PropTypes.any,
+  text: PropTypes.string,
+  textStyle: PropTypes.any
 }
 
 export default Button

--- a/Login/Structure/Input/Input.js
+++ b/Login/Structure/Input/Input.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { View, TextInput, Image } from 'react-native'
 
 const Input = (props) => {
@@ -20,10 +21,10 @@ const Input = (props) => {
 }
 
 Input.propTypes = {
-  icon: React.PropTypes.any,
-  iconStyle: React.PropTypes.any,
-  label: React.PropTypes.string,
-  wrapperStyle: React.PropTypes.any
+  icon: PropTypes.any,
+  iconStyle: PropTypes.any,
+  label: PropTypes.string,
+  wrapperStyle: PropTypes.any
 }
 
 export default Input

--- a/Login/Structure/Logo/Logo.js
+++ b/Login/Structure/Logo/Logo.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Image } from 'react-native'
 
 const Logo = (props) => {
@@ -12,8 +13,8 @@ const Logo = (props) => {
 }
 
 Logo.propTypes = {
-  style: React.PropTypes.any,
-  image: React.PropTypes.any
+  style: PropTypes.any,
+  image: PropTypes.any
 }
 
 export default Logo

--- a/Login/index.js
+++ b/Login/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import DefaultStyles from './DefaultStyles'
 import defaultLabels from './constants/defaultLabels'
 
@@ -69,34 +70,34 @@ class Login extends Component {
 }
 
 Login.propTypes = {
-  labels: React.PropTypes.object,
-  logoImage: React.PropTypes.any,
-  onLogin: React.PropTypes.func.isRequired,
-  onResetPassword: React.PropTypes.func,
-  passwordInputIcon: React.PropTypes.any,
-  resetPasswordHeaderRenderer: React.PropTypes.func,
-  showLogoOnLogin: React.PropTypes.bool,
-  showLogoOnResetPassword: React.PropTypes.bool,
-  userIdentificationInputIcon: React.PropTypes.any,
-  inputPlaceholderTextColor: React.PropTypes.string,
+  labels: PropTypes.object,
+  logoImage: PropTypes.any,
+  onLogin: PropTypes.func.isRequired,
+  onResetPassword: PropTypes.func,
+  passwordInputIcon: PropTypes.any,
+  resetPasswordHeaderRenderer: PropTypes.func,
+  showLogoOnLogin: PropTypes.bool,
+  showLogoOnResetPassword: PropTypes.bool,
+  userIdentificationInputIcon: PropTypes.any,
+  inputPlaceholderTextColor: PropTypes.string,
 
-  backButtonStyle: React.PropTypes.any,
-  backButtonTextStyle: React.PropTypes.any,
-  baseButtonStyle: React.PropTypes.any,
-  baseButtonTextStyle: React.PropTypes.any,
-  inputIconStyle: React.PropTypes.any,
-  loginResetPasswordLinkStyle: React.PropTypes.any,
-  loginResetPasswordLinkTextStyle: React.PropTypes.any,
-  fieldsetWrapperStyle: React.PropTypes.any,
-  inputWrapperStyle: React.PropTypes.any,
-  inputStyle: React.PropTypes.any,
-  loginFormSubmitButtonStyle: React.PropTypes.any,
-  loginFormSubmitButtonTextStyle: React.PropTypes.any,
-  loginFormWrapperStyle: React.PropTypes.any,
-  logoStyle: React.PropTypes.any,
-  resetPasswordFormWrapperStyle: React.PropTypes.any,
-  resetPasswordFormSubmitButtonTextStyle: React.PropTypes.any,
-  resetPasswordFormSubmitButtonStyle: React.PropTypes.any
+  backButtonStyle: PropTypes.any,
+  backButtonTextStyle: PropTypes.any,
+  baseButtonStyle: PropTypes.any,
+  baseButtonTextStyle: PropTypes.any,
+  inputIconStyle: PropTypes.any,
+  loginResetPasswordLinkStyle: PropTypes.any,
+  loginResetPasswordLinkTextStyle: PropTypes.any,
+  fieldsetWrapperStyle: PropTypes.any,
+  inputWrapperStyle: PropTypes.any,
+  inputStyle: PropTypes.any,
+  loginFormSubmitButtonStyle: PropTypes.any,
+  loginFormSubmitButtonTextStyle: PropTypes.any,
+  loginFormWrapperStyle: PropTypes.any,
+  logoStyle: PropTypes.any,
+  resetPasswordFormWrapperStyle: PropTypes.any,
+  resetPasswordFormSubmitButtonTextStyle: PropTypes.any,
+  resetPasswordFormSubmitButtonStyle: PropTypes.any
 }
 
 Login.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
   ],
   "author": "Thiago Porto",
   "license": "MIT",
-  "dependencies": {
-    "react": ">=15.4.1",
-    "react-native": ">=0.38.0"
-  },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "babel-preset-react-native": "^1.9.1",


### PR DESCRIPTION
@VizirAdmin this was holding me back from using the most recent version of react. I think this should eventually be integrated into the simple forms to keep this project up to date for others. I am not a react-native expert so feel free to let me know if there is something I am missing. 